### PR TITLE
Enhance README and server functionality for merge request comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ The MCP server provides the following tools for interacting with GitLab:
 | `fetch_merge_request_diff` | Get diffs for a specific merge request |
 | `fetch_commit_diff` | Get diff information for a specific commit |
 | `compare_versions` | Compare different branches, tags, or commits |
-| `add_merge_request_comment` | Add a comment to a merge request |
+| `add_merge_request_comment` | Add a regular or resolvable comment to a merge request |
+| `get_merge_request_comments` | Fetch all comments on a merge request |
 | `approve_merge_request` | Approve a merge request |
 | `unapprove_merge_request` | Unapprove a merge request |
 | `get_project_merge_requests` | Get a list of merge requests for a project |
@@ -172,8 +173,21 @@ diff = compare_versions("123", "develop", "master")
 ### Add a Comment to a Merge Request
 
 ```python
-# Add a comment to a merge request
+# Add a regular comment to a merge request
 comment = add_merge_request_comment("123", "5", "This code looks good!")
+
+# Add a resolvable discussion thread (can be marked resolved/unresolved)
+comment = add_merge_request_comment("123", "5", "Please fix this.", resolvable=True)
+```
+
+### Fetch Comments on a Merge Request
+
+```python
+# Get all comments, oldest first (default)
+comments = get_merge_request_comments("123", "5")
+
+# Get comments sorted by most recently updated
+comments = get_merge_request_comments("123", "5", sort="desc", order_by="updated_at")
 ```
 
 ### Approve a Merge Request

--- a/server.py
+++ b/server.py
@@ -90,9 +90,7 @@ async def gitlab_lifespan(server: FastMCP) -> AsyncIterator[GitLabContext]:
 # Create MCP server
 mcp = FastMCP(
     "GitLab MCP for Code Review",
-    description="MCP server for reviewing GitLab code changes",
-    lifespan=gitlab_lifespan,
-    dependencies=["python-dotenv", "requests"]
+    lifespan=gitlab_lifespan
 )
 
 @mcp.tool()
@@ -221,35 +219,57 @@ def compare_versions(ctx: Context, project_id: str, from_sha: str, to_sha: str) 
     return compare_info
 
 @mcp.tool()
-def add_merge_request_comment(ctx: Context, project_id: str, merge_request_iid: str, body: str, position: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def add_merge_request_comment(ctx: Context, project_id: str, merge_request_iid: str, body: str, position: Optional[Dict[str, Any]] = None, resolvable: bool = False) -> Dict[str, Any]:
     """
     Add a comment to a merge request, optionally at a specific position in a file.
-    
+
     Args:
         project_id: The GitLab project ID or URL-encoded path
         merge_request_iid: The merge request IID (project-specific ID)
         body: The comment text
         position: Optional position data for line comments
+        resolvable: If True, creates the comment as a resolvable discussion thread
+                    via the /discussions endpoint. Regular notes (/notes) are not resolvable.
     Returns:
         Dict containing the created comment information
     """
-    # Create the comment data
-    data = {
-        "body": body
-    }
-    
-    # Add position data if provided
+    data = {"body": body}
+
     if position:
         data["position"] = position
-    
-    # Add the comment
-    comment_endpoint = f"projects/{quote(project_id, safe='')}/merge_requests/{merge_request_iid}/notes"
-    comment_info = make_gitlab_api_request(ctx, comment_endpoint, method="POST", data=data)
-    
+
+    if resolvable:
+        endpoint = f"projects/{quote(project_id, safe='')}/merge_requests/{merge_request_iid}/discussions"
+    else:
+        endpoint = f"projects/{quote(project_id, safe='')}/merge_requests/{merge_request_iid}/notes"
+
+    comment_info = make_gitlab_api_request(ctx, endpoint, method="POST", data=data)
+
     if not comment_info:
         raise ValueError("Failed to add comment to merge request")
-    
+
     return comment_info
+
+@mcp.tool()
+def get_merge_request_comments(ctx: Context, project_id: str, merge_request_iid: str, sort: str = "asc", order_by: str = "created_at") -> List[Dict[str, Any]]:
+    """
+    Fetch all comments (notes) on a merge request.
+
+    Args:
+        project_id: The GitLab project ID or URL-encoded path
+        merge_request_iid: The merge request IID (project-specific ID)
+        sort: Sort order (asc or desc) - default: asc
+        order_by: Order by field (created_at or updated_at) - default: created_at
+    Returns:
+        List of comment objects
+    """
+    notes_endpoint = f"projects/{quote(project_id, safe='')}/merge_requests/{merge_request_iid}/notes?sort={sort}&order_by={order_by}"
+    notes = make_gitlab_api_request(ctx, notes_endpoint)
+
+    if notes is None:
+        raise ValueError(f"Failed to fetch comments for merge request {merge_request_iid}")
+
+    return notes
 
 @mcp.tool()
 def approve_merge_request(ctx: Context, project_id: str, merge_request_iid: str, approvals_required: Optional[int] = None) -> Dict[str, Any]:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -35,6 +35,80 @@ class TestGitLabMCP(unittest.TestCase):
         mock_get.assert_called_once()
         self.assertEqual(result, {"id": 123, "name": "test_project"})
 
+    @patch('requests.post')
+    def test_add_merge_request_comment_regular(self, mock_post):
+        """Test adding a regular (non-resolvable) comment uses the /notes endpoint"""
+        from server import add_merge_request_comment
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"id": 1, "body": "Great work!"}
+        mock_post.return_value = mock_response
+
+        result = add_merge_request_comment(self.mock_ctx, "123", "5", "Great work!")
+
+        call_url = mock_post.call_args[0][0]
+        self.assertIn("/notes", call_url)
+        self.assertNotIn("/discussions", call_url)
+        self.assertEqual(result, {"id": 1, "body": "Great work!"})
+
+    @patch('requests.post')
+    def test_add_merge_request_comment_resolvable(self, mock_post):
+        """Test adding a resolvable comment uses the /discussions endpoint"""
+        from server import add_merge_request_comment
+
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {"id": 2, "notes": [{"body": "Please fix this"}]}
+        mock_post.return_value = mock_response
+
+        result = add_merge_request_comment(self.mock_ctx, "123", "5", "Please fix this", resolvable=True)
+
+        call_url = mock_post.call_args[0][0]
+        self.assertIn("/discussions", call_url)
+        self.assertNotIn("/notes", call_url)
+        self.assertEqual(result, {"id": 2, "notes": [{"body": "Please fix this"}]})
+
+    @patch('requests.get')
+    def test_get_merge_request_comments(self, mock_get):
+        """Test fetching comments for a merge request"""
+        from server import get_merge_request_comments
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": 1, "body": "First comment"},
+            {"id": 2, "body": "Second comment"},
+        ]
+        mock_get.return_value = mock_response
+
+        result = get_merge_request_comments(self.mock_ctx, "123", "5")
+
+        mock_get.assert_called_once()
+        call_url = mock_get.call_args[0][0]
+        self.assertIn("/notes", call_url)
+        self.assertIn("sort=asc", call_url)
+        self.assertIn("order_by=created_at", call_url)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["body"], "First comment")
+
+    @patch('requests.get')
+    def test_get_merge_request_comments_custom_sort(self, mock_get):
+        """Test fetching comments with custom sort and order_by parameters"""
+        from server import get_merge_request_comments
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [{"id": 3, "body": "Latest comment"}]
+        mock_get.return_value = mock_response
+
+        result = get_merge_request_comments(self.mock_ctx, "123", "5", sort="desc", order_by="updated_at")
+
+        call_url = mock_get.call_args[0][0]
+        self.assertIn("sort=desc", call_url)
+        self.assertIn("order_by=updated_at", call_url)
+        self.assertEqual(len(result), 1)
+
 
 if __name__ == '__main__':
-    unittest.main() 
+    unittest.main()


### PR DESCRIPTION
- Updated README.md to include details for adding regular and resolvable comments to merge requests.
- Added `get_merge_request_comments` function to fetch all comments on a merge request with sorting options.
- Modified `add_merge_request_comment` function to support resolvable comments via the discussions endpoint.
- Added unit tests for new comment functionalities.